### PR TITLE
Individual packages for each extension, per PHP version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-swoole-*.tgz
+*.tgz

--- a/README.md
+++ b/README.md
@@ -5,5 +5,9 @@ This repository contains tools for pre-building the Swoole and OpenSwoole extens
 The [Makefile](Makefile) can be used to do the following:
 
 - Build Docker containers for different PHP versions that are ready for building extensions.
-- Use the above Docker containers to build each of the Swoole and OpenSwoole extensions.
-- Package and upload the extensions (currently only to S3).
+- Use the above Docker containers to build and package each of the Swoole and OpenSwoole extensions, for individual PHP versions or for all PHP versions currently supported.
+
+## Packages
+
+Packages should be uploaded as release artifacts to tagged releases.
+Releases should be tagged each time a new PHP version is added, or a version for Swoole or OpenSwoole is changed.


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | no
| BC Break      | yes
| New Feature   | yes
| RFC           | no
| QA            | no

### Description

Updates the `Makefile` to build and package per PHP version, allowing the ability to download a package specific to the extension and PHP version required.

Generally speaking, `make all` will now build individual swoole and openswoole packages for all supported PHP versions.

Generated packages are named `php{VERSION}-(swoole|openswoole).tgz`.
