### PR TITLE
Added PHP 8.2 to the list of build envs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,8 @@ HERE := $(dir $(realpath $(firstword $(MAKEFILE_LIST))))
 ##########################################################
 
 PHP_VERSION := 7.4
-SWOOLE_VERSION := 4.8.11
-OPEN_SWOOLE_VERSION := 4.11.1
+SWOOLE_VERSION := 4.8.12
+OPEN_SWOOLE_VERSION := 4.12.0
 
 .PHONY:
 

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ container:  ## Build a single PHP container based on PHP_VERSION
 
 containers:  ## Create all PHP containers for building extensions
 	@printf "\n\033[92mBuilding all containers ...\033[0m\n"
-	for VERSION in 7.3 7.4 8.0 8.1;do \
+	for VERSION in 7.3 7.4 8.0 8.1 8.2;do \
 		printf "\n\033[92mBuilding container for PHP $$VERSION ...\033[0m\n" ; \
 		docker build -t laminas/laminas-ext-builder:$$VERSION --build-arg PHP_VERSION=$$VERSION . ; \
 		printf "\n\033[92mBuilt container for PHP $$VERSION\033[0m\n" ; \
@@ -51,7 +51,7 @@ openswoole: clean-artifacts  ## Build OpenSwoole version OPEN_SWOOLE_VERSION usi
 	@printf "\n\033[92mBuilt and packaged OpenSwoole $(OPEN_SWOOLE_VERSION) for PHP version $(PHP_VERSION)\033[0m\n"
 
 all:  ## Build and package both Swoole and OpenSwoole for all supported PHP versions
-	for VERSION in 7.3 7.4 8.0 8.1;do \
+	for VERSION in 7.3 7.4 8.0 8.1 8.2;do \
 		cd $(HERE) ; \
 		make swoole PHP_VERSION=$$VERSION ; \
 		cd $(HERE) ; \


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | no

### Description

This PR adds support to build swoole extensions on PHP 8.2.

It also updates swoole to 4.8.12 and openswoole to 4.12.0, as these versions introduce support for PHP 8.2
